### PR TITLE
Update Makefile to point to the new staging repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BIN := cluster-proportional-autoscaler
 PKG := github.com/kubernetes-incubator/cluster-proportional-autoscaler
 
 # Where to push the docker image.
-REGISTRY ?= staging-k8s.gcr.io
+REGISTRY ?= gcr.io/k8s-staging-cpa
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64


### PR DESCRIPTION
The old staging repo is now deprecated: https://groups.google.com/g/kubernetes-sig-release/c/lFmJZKwIxyI/m/ytVrkTYNAQAJ