### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ data:
       "nodesPerReplica": 1,
       "min": 1,
       "max": 100,
-      "preventSinglePointFailure": true,
-      "includeUnschedulableNodes": true
+      "preventSinglePointFailure": "true",
+      "includeUnschedulableNodes": "true"
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ data:
       "nodesPerReplica": 1,
       "min": 1,
       "max": 100,
-      "preventSinglePointFailure": true
+      "preventSinglePointFailure": true,
       "includeUnschedulableNodes": true
     }
 ```


### PR DESCRIPTION
Added missing coma in JSON. (Typo in README.md that leads to broken config).

Without this comma, the pod is not created, instead you get the error:
`error: error parsing dns-autoscaler.yaml: error converting YAML to JSON: yaml: line 31: mapping values are not allowed in this context`