### PR TITLE
remove USER in Dockerfile

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -18,6 +18,4 @@ MAINTAINER Zihong Zheng <zihongz@google.com>
 
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
-USER nonroot:nonroot
-
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
Kubernetes with a pod security policy runAsNonRoot can't validate if user is non-root if it isn't numeric:

`Error: container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root`

As the image gcr.io/distroless/static:nonroot already uses non-root user (65532) there is no need to specify it again.
@sozercan is there a specific reason you added it?

Tested with Kubernetes 1.18 and a runAsNonRoot user restricted PSP.