### PR TITLE
Change minimum replicas to zero in laddermode

### DIFF
--- a/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
+++ b/pkg/autoscaler/controller/laddercontroller/ladder_controller.go
@@ -131,7 +131,7 @@ func (c *LadderController) getExpectedReplicasFromParams(schedulableNodes, sched
 
 func getExpectedReplicasFromEntries(schedulableResources int, entries []paramEntry) int {
 	if len(entries) == 0 {
-		return 1
+		return 0
 	}
 	// Binary search for the corresponding replicas number
 	pos := sort.Search(


### PR DESCRIPTION
This PR fixes the Issue metioned in https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/issues/110.
