### PR TITLE
Add a helm chart

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "helm-chart-{{ .Name }}-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,27 @@
+name: Release Helm Charts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "charts/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/cr.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.push-*
 /.container-*
 /.dockerfile-*
+/.idea/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Usage of cluster-proportional-autoscaler:
       --max-sync-failures=[0]: Number of consecutive polling failures before exiting. Default value of 0 will allow for unlimited retries.
 ```
 
+## Installation with helm
+
+Add the cluster-proportional-autoscaler Helm repository:
+```sh
+helm repo add cluster-proportional-autoscaler https://kubernetes-sigs.github.io/cluster-proportional-autoscaler
+helm repo update
+```
+
+Then install a release using the chart.  The [charts default values file](charts/cluster-proportional-autoscaler/values.yaml) provides some commented out examples for setting some of the values.  There are several required values, but helm should fail with messages that indicate which value is missing.
+```sh
+helm upgrade --install cluster-proportional-autoscaler \
+    cluster-proportional-autoscaler/cluster-proportional-autoscaler --values <<name_of_your_values_file>>.yaml
+```
+
 ## Examples
 
 Please try out the examples in [the examples folder](examples/).
@@ -90,9 +104,9 @@ replicas to take care of all 13 cores. Controller will choose the greater one, w
 
 When `includeUnschedulableNodes` is set to `true`, the replicas will scale based on the total number of nodes.
 Otherwise, the replicas will only scale based on the number of schedulable nodes (i.e., cordoned and draining nodes are
-excluded.) 
+excluded.)
 
-Either one of the `coresPerReplica` or `nodesPerReplica` could be omitted. All of  `min`, `max`, 
+Either one of the `coresPerReplica` or `nodesPerReplica` could be omitted. All of  `min`, `max`,
 `preventSinglePointFailure` and `includeUnscheduleableNodes` are optional. If not set, `min` would be default to `1`,
 `preventSinglePointFailure` will be default to `false` and `includeUnschedulableNodes` will be default to `false`.
 

--- a/charts/cluster-proportional-autoscaler/.helmignore
+++ b/charts/cluster-proportional-autoscaler/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cluster-proportional-autoscaler/Chart.yaml
+++ b/charts/cluster-proportional-autoscaler/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: cluster-proportional-autoscaler
+version: 1.0.0
+appVersion: 1.8.4
+description: This chart is used to deploy an instance of the cluster-proportional-autoscaler.
+maintainers:
+  - name: krmichel
+    url: https://github.com/krmichel
+  - name: d-mcd
+    url: https://github.com/d-mcd

--- a/charts/cluster-proportional-autoscaler/templates/_helpers.tpl
+++ b/charts/cluster-proportional-autoscaler/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cluster-proportional-autoscaler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cluster-proportional-autoscaler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cluster-proportional-autoscaler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cluster-proportional-autoscaler.labels" -}}
+helm.sh/chart: {{ include "cluster-proportional-autoscaler.chart" . }}
+{{ include "cluster-proportional-autoscaler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cluster-proportional-autoscaler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cluster-proportional-autoscaler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-proportional-autoscaler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cluster-proportional-autoscaler.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate node values based on provided values
+*/}}
+{{- define "cluster-proportional-autoscaler.nodeLables" -}}
+{{- if .Values.options.nodeLabels }}
+{{- $labels := list }}
+{{- range $k, $v := .Values.options.nodeLabels }}
+{{- $labels = mustAppend $labels (printf "%s=%s" $k $v) }}
+{{- end }}
+{{- join "," $labels }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]

--- a/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cluster-proportional-autoscaler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/cluster-proportional-autoscaler/templates/configmap.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{ $config := pick .Values.config "ladder" "linear" }}
+{{ if not $config }}
+{{ fail "A config must be supplied for either ladder mode or linear mode" }}
+{{- end }}
+{{- if and $config.ladder $config.linear }}
+{{ fail "You must supply a config for either ladder mode or linear mode but not both" }}
+{{- end }}
+{{ $key := mustFirst (keys $config) }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.options.namespace }}
+data:
+  {{ $key }}: |-
+    {{- get $config $key | mustToJson | nindent 4 }}

--- a/charts/cluster-proportional-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/deployment.yaml
@@ -1,0 +1,91 @@
+{{- $target := default "" .Values.options.target }}
+{{- if and (and (not (hasPrefix "deployment/" $target)) (not (hasPrefix "replicationcontroller/" $target))) (not (hasPrefix "replicaset/" $target)) }}
+{{ fail "options.target must be one of deployment, replicationcontroller, or replicaset" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cluster-proportional-autoscaler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cluster-proportional-autoscaler.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "cluster-proportional-autoscaler.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --configmap={{ include "cluster-proportional-autoscaler.fullname" . }}
+            - --logtostderr={{ ternary true false (not (empty .Values.options.logToStdErr)) }}
+            - --namespace={{ default .Release.Namespace .Values.options.namespace }}
+            - --target={{- required "options.target must be specified" $target }}
+            - --v={{ .Values.options.logLevel | int }}
+            {{- with ternary true false (not (empty .Values.options.alsoLogToStdErr)) }}
+            - --alsologtostderr={{ . }}
+            {{- end }}
+            {{- with .Values.options.logBacktraceAt }}
+            - --log-backtrace-at={{ . }}
+            {{- end }}
+            {{- with .Values.options.logDir }}
+            - --log-dir={{ . }}
+            {{- end }}
+            {{- with .Values.options.maxSyncFailures | toString }}
+            - --max-sync-failures={{ ternary (. | int) 0 (ge (. | int) 0) }}
+            {{- end }}
+            {{- with (include "cluster-proportional-autoscaler.nodeLables" .) }}
+            - --nodelabels={{ . }}
+            {{- end }}
+            {{- with .Values.options.pollPeriodSeconds }}
+            - --poll-period-seconds={{ ternary (. | int) 1 (gt (. | int) 0) }}
+            {{- end }}
+            {{- with .Values.options.stdErrThreshold }}
+            - --stderrthreshold={{ . }}
+            {{- end }}
+            {{- with .Values.options.vmodule }}
+            - --vmodule={{ . }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cluster-proportional-autoscaler/templates/role.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/role.yaml
@@ -1,0 +1,17 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.options.namespace }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions","apps"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]

--- a/charts/cluster-proportional-autoscaler/templates/rolebinding.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.options.namespace }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cluster-proportional-autoscaler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cluster-proportional-autoscaler.serviceAccountName" . }}
+  labels:
+    {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -19,7 +19,7 @@ config: {}
 #    preventSinglePointFailure: true
 #    includeUnschedulableNodes: true
 image:
-  repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler-amd64
+  repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
   pullPolicy: IfNotPresent
   tag:
 imagePullSecrets: []

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -1,0 +1,75 @@
+affinity: {}
+config: {}
+#  ladder:
+#    coresToReplicas:
+#      - [ 1, 1 ]
+#      - [ 64, 3 ]
+#      - [ 512, 5 ]
+#      - [ 1024, 7 ]
+#      - [ 2048, 10 ]
+#      - [ 4096, 15 ]
+#    nodesToReplicas:
+#      - [ 1, 1 ]
+#      - [ 2, 2 ]
+#  linear:
+#    coresPerReplica: 2
+#    nodesPerReplica: 1
+#    min: 1
+#    max: 100
+#    preventSinglePointFailure: true
+#    includeUnschedulableNodes: true
+image:
+  repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler-amd64
+  pullPolicy: IfNotPresent
+  tag:
+imagePullSecrets: []
+fullnameOverride:
+nameOverride:
+nodeSelector: {}
+options:
+  alsoLogToStdErr:
+  logBacktraceAt:
+  logDir:
+  #  --v=0: log level for V logs
+  logLevel:
+  # Defaulting to true limits use of ephemeral storage
+  logToStdErr: true
+  maxSyncFailures:
+  namespace:
+  nodeLabels: {}
+  #    label1: value1
+  #    label2: value2
+  pollPeriodSeconds:
+  stdErrThreshold:
+  target:
+  vmodule:
+podAnnotations: {}
+podSecurityContext: {}
+# fsGroup: 2000
+replicaCount: 1
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+serviceAccount:
+  create: true
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # If set and create is false, no service account will be created and the expectation is that the provided service account already exists or it will use the "default" service account
+  name:
+tolerations: []


### PR DESCRIPTION
Fixes #103 

Before this is merged there will need to be a `gh-pages` branch created (probably with nothing but a .gitignore file in it) to house the chart repo's index.yaml.  If you need any help let me know and I can provide some git commands to help with that.  In the event that the `gh-pages` branch is protected here is a PR in another kubernetes-sigs repo that needed to be changed with a reference to a change in test-infra

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/624