### PR TITLE
Support custom `priorityClassName` in the helm chart

### DIFF
--- a/charts/cluster-proportional-autoscaler/Chart.yaml
+++ b/charts/cluster-proportional-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-proportional-autoscaler
-version: 1.0.0
-appVersion: 1.8.4
+version: 1.0.1
+appVersion: 1.8.6
 description: This chart is used to deploy an instance of the cluster-proportional-autoscaler.
 maintainers:
   - name: krmichel

--- a/charts/cluster-proportional-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/deployment.yaml
@@ -89,3 +89,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -73,3 +73,4 @@ serviceAccount:
   # If set and create is false, no service account will be created and the expectation is that the provided service account already exists or it will use the "default" service account
   name:
 tolerations: []
+priorityClassName: ""

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -37,15 +37,15 @@ options:
   maxSyncFailures:
   namespace:
   nodeLabels: {}
-  #    label1: value1
-  #    label2: value2
+  #  label1: value1
+  #  label2: value2
   pollPeriodSeconds:
   stdErrThreshold:
   target:
   vmodule:
 podAnnotations: {}
 podSecurityContext: {}
-# fsGroup: 2000
+  # fsGroup: 2000
 replicaCount: 1
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -57,14 +57,14 @@ resources: {}
   #   memory: 128Mi
   # requests:
   #   cpu: 100m
-#   memory: 128Mi
+  #   memory: 128Mi
 securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-# runAsUser: 1000
+  # runAsUser: 1000
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
This will allow us to use the Helm chart for things like [CoreDNS autoscaler](https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/#enablng-dns-horizontal-autoscaling).

This PR also bumps the chart version and app version (may conflict with #126).