### PR TITLE
Bump golang version to 1.19.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ OUTPUT_TYPE ?= docker
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 
-BUILD_IMAGE ?= golang:1.18.4-alpine
+BUILD_IMAGE ?= golang:1.19.4-alpine
 
 MULTIARCH_IMAGE := $(REGISTRY)/$(BIN)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/cluster-proportional-autoscaler
 
-go 1.18
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/pkg/autoscaler/health.go
+++ b/pkg/autoscaler/health.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package autoscaler
 
 import (


### PR DESCRIPTION
- Fix a gofmt error to pass the test.


Ref https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/issues/131.