### PR TITLE
Switch Chart Default Registry to registry.k8s.io

### DIFF
--- a/charts/cluster-proportional-autoscaler/Chart.yaml
+++ b/charts/cluster-proportional-autoscaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cluster-proportional-autoscaler
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.8.6
 description: This chart is used to deploy an instance of the cluster-proportional-autoscaler.
 maintainers:

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -19,7 +19,7 @@ config: {}
 #    preventSinglePointFailure: true
 #    includeUnschedulableNodes: true
 image:
-  repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
+  repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
   pullPolicy: IfNotPresent
   tag:
 imagePullSecrets: []


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/issues/4738, updating the Chart's default registry to `registry.k8s.io`.