### PR TITLE
Add namespace to deployment and serviceaccount to work with argocd

### DIFF
--- a/charts/cluster-proportional-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/deployment.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cluster-proportional-autoscaler.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.options.namespace }}
   labels:
     {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
 spec:

--- a/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cluster-proportional-autoscaler.serviceAccountName" . }}
+  namespace: {{ default .Release.Namespace .Values.options.namespace }}
   labels:
     {{- include "cluster-proportional-autoscaler.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
ArgoCD depending on your configuration, require that every Kubernetes resources need a namespace declaration.

I add this configuration to the helm chart template because values.yaml already has this value.