### PR TITLE
Helm chart: Put RBAC resources behind a boolean flag

### DIFF
--- a/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.rbac.create -}}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -8,3 +10,4 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list", "watch"]
+{{- end -}}

--- a/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.rbac.clusterScoped -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.rbac.clusterScoped -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "cluster-proportional-autoscaler.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/cluster-proportional-autoscaler/templates/role.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/role.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.rbac.create -}}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -15,3 +17,4 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+{{- end -}}

--- a/charts/cluster-proportional-autoscaler/templates/rolebinding.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,3 +15,4 @@ roleRef:
   kind: Role
   name: {{ include "cluster-proportional-autoscaler.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.rbac.create .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -46,6 +46,8 @@ options:
 podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
+rbac:
+  create: true
 replicaCount: 1
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cluster-proportional-autoscaler/values.yaml
+++ b/charts/cluster-proportional-autoscaler/values.yaml
@@ -47,6 +47,7 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 rbac:
+  clusterScoped: true
   create: true
 replicaCount: 1
 resources: {}


### PR DESCRIPTION
Place RBAC resources behind a new boolean flag `rbac.create`, so their creation can be disabled. Additionally adds a flag `rbac.clusterScoped`, which can be used to disable creation of cluster-scoped resources specifically. This is useful for scenarios where someone may wish to use the chart to manage an instance in their namespace, but does not have permission to create cluster resources.