### PR TITLE
Fix options provided to CPA's Nodes List and Watch requests

### DIFF
--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -83,14 +83,14 @@ func NewK8sClient(namespace, target string, nodelabels string) (K8sClient, error
 	}
 
 	// Start propagating contents of the nodeStore.
-
-	opts := metav1.ListOptions{LabelSelector: nodelabels}
 	nodeListWatch := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return clientset.CoreV1().Nodes().List(context.TODO(), opts)
+			options.LabelSelector = nodelabels
+			return clientset.CoreV1().Nodes().List(context.TODO(), options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return clientset.CoreV1().Nodes().Watch(context.TODO(), opts)
+			options.LabelSelector = nodelabels
+			return clientset.CoreV1().Nodes().Watch(context.TODO(), options)
 		},
 	}
 	nodeStore := cache.NewStore(cache.MetaNamespaceKeyFunc)


### PR DESCRIPTION
Before this PR, we completely disregarded the `ListOptions` argument passed to the relevant `ListFunc` and `WatchFunc` in the Nodes reflector. This resulted in list and watches going directly to etcd as we didn't pass `resourceVersion` to the API calls reaching apiserver.

/assign @MrHohn
/cc @wojtek-t