### PR TITLE
Helm Chart: Fix for the helm lint error

### DIFF
--- a/charts/cluster-proportional-autoscaler/templates/configmap.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/configmap.yaml
@@ -12,5 +12,7 @@ metadata:
   name: {{ include "cluster-proportional-autoscaler.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.options.namespace }}
 data:
+  {{- if $key }}
   {{ $key }}: |-
     {{- get $config $key | mustToJson | nindent 4 }}
+  {{- end }}


### PR DESCRIPTION
The helm linting fails due to the config value not being set.  The error:
> [ERROR] templates/: template: cluster-proportional-autoscaler/templates/configmap.yaml:16:20: executing "cluster-proportional-autoscaler/templates/configmap.yaml" at <$key>: invalid value; expected string

This is causing some automated checks to fail for charts using this one as a dependency.