### PR TITLE
Multi-target support

### DIFF
--- a/pkg/autoscaler/autoscaler_server.go
+++ b/pkg/autoscaler/autoscaler_server.go
@@ -137,7 +137,7 @@ func (s *AutoScaler) pollAPIServer() error {
 	glog.V(4).Infof("Expected replica count: %3d", expReplicas)
 
 	// Update resource target with expected replicas.
-	_, err = s.k8sClient.UpdateReplicas(expReplicas)
+	err = s.k8sClient.UpdateReplicas(expReplicas)
 	if err != nil {
 		glog.Errorf("Update failure: %s", err)
 	}

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -136,7 +136,7 @@ type target struct {
 	name string
 }
 
-// scaleTargets stores the scalable target recourses
+// scaleTargets stores the scalable target resources
 type scaleTargets struct {
 	targets   []target
 	namespace string

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -116,7 +116,7 @@ func TestGetScaleTarget(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		res, err := getScaleTarget(tc.target, "default")
+		res, err := getScaleTargets(tc.target, "default")
 		if err != nil && !tc.expError {
 			t.Errorf("Expect no error, got error for target: %v", tc.target)
 			continue

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestGetScaleTarget(t *testing.T) {
+func TestGetTarget(t *testing.T) {
 	testCases := []struct {
 		target   string
 		expKind  string
@@ -54,7 +54,7 @@ func TestGetScaleTarget(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		res, err := getScaleTarget(tc.target, "default")
+		res, err := getTarget(tc.target)
 		if err != nil && !tc.expError {
 			t.Errorf("Expect no error, got error for target: %v", tc.target)
 			continue
@@ -64,6 +64,76 @@ func TestGetScaleTarget(t *testing.T) {
 		}
 		if res.kind != tc.expKind || res.name != tc.expName {
 			t.Errorf("Expect kind: %v, name: %v\ngot kind: %v, name: %v", tc.expKind, tc.expName, res.kind, res.name)
+		}
+	}
+}
+
+func TestGetScaleTarget(t *testing.T) {
+	testCases := []struct {
+		target          string
+		expScaleTargets *scaleTargets
+		expError        bool
+	}{
+		{
+			"deployment/anything",
+			&scaleTargets{
+				targets: []target{
+					{kind: "deployment", name: "anything"},
+				},
+			},
+			false,
+		},
+		{
+			"deployment/first,deployment/second",
+			&scaleTargets{
+				targets: []target{
+					{kind: "deployment", name: "first"},
+					{kind: "deployment", name: "second"},
+				},
+			},
+			false,
+		},
+		{
+			"deployment/first, deployment/second",
+			&scaleTargets{
+				targets: []target{
+					{kind: "deployment", name: "first"},
+					{kind: "deployment", name: "second"},
+				},
+			},
+			false,
+		},
+		{
+			"deployment/first deployment/second",
+			&scaleTargets{
+				targets: []target{
+					{kind: "deployment", name: "first"},
+					{kind: "deployment", name: "second"},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		res, err := getScaleTarget(tc.target, "default")
+		if err != nil && !tc.expError {
+			t.Errorf("Expect no error, got error for target: %v", tc.target)
+			continue
+		} else if err == nil && tc.expError {
+			t.Errorf("Expect error, got no error for target: %v", tc.target)
+			continue
+		}
+		if len(res.targets) != len(tc.expScaleTargets.targets) && !tc.expError {
+			t.Errorf("Expected targets vs resulted targets should be the same length: %v vs %v", len(tc.expScaleTargets.targets), len(res.targets))
+			continue
+		}
+		for idx := 1; idx <= len(res.targets); idx++ {
+			if res.targets[0].kind != tc.expScaleTargets.targets[0].kind ||
+				res.targets[0].name != tc.expScaleTargets.targets[0].name {
+				t.Errorf("Expect kind: %v, name: %v\ngot kind: %v, name: %v", tc.expScaleTargets.targets[0].kind,
+					tc.expScaleTargets.targets[0].name, res.targets[0].kind, res.targets[0].name)
+			}
 		}
 	}
 }

--- a/pkg/autoscaler/k8sclient/mock_k8sclient.go
+++ b/pkg/autoscaler/k8sclient/mock_k8sclient.go
@@ -69,8 +69,7 @@ func (k *MockK8sClient) GetNamespace() string {
 }
 
 // UpdateReplicas mocks updating the number of replicas for the resource and return the previous replicas count
-func (k *MockK8sClient) UpdateReplicas(expReplicas int32) (int32, error) {
-	prevReplicas := int32(k.NumOfReplicas)
+func (k *MockK8sClient) UpdateReplicas(expReplicas int32) error {
 	k.NumOfReplicas = int(expReplicas)
-	return prevReplicas, nil
+	return nil
 }


### PR DESCRIPTION
Hi, I've encountered a use case where I have multiple deployments that need to scale the same in the same namespace, right now the solution is to deploy multiple CPA deployments which seems a bit redundant. Plus some chart dependency complications that with be easily solved if the CPA supported multiple tagerts.

Looking at the code the support for multiple targets was pretty straightforward, I don't see any downsides to it so I've added the changes. Any concerns or suggestions about this feature?