### PR TITLE
Add includeUnschedulableNodes option to ladder controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ data:
       [
         [ 1, 1 ],
         [ 2, 2 ]
-      ]
+      ],
+      "includeUnschedulableNodes": false
     }
 ```
 
@@ -148,8 +149,12 @@ The replicas derived from "cores_to_replicas_map" would be `3` (because `64` < `
 The replicas derived from "nodes_to_replicas_map" would be `2` (because `100` > `2`).
 And we would choose the larger one `3`.
 
+When `includeUnschedulableNodes` is set to `true`, the replicas will scale based on total number of nodes or cores.
+Otherwise, the replicas will only scale based on the number of schedulable nodes (i.e., cordoned and draining nodes are
+excluded.)
+
 Either one of the `coresToReplicas` or `nodesToReplicas` could be omitted. All elements in them should
-be int.
+be int. `includeUnschedulableNodes` will default to `false`.
 
 Replicas can be set to 0 (unlike in linear mode).
 

--- a/examples/ladder-defaultparams.yaml
+++ b/examples/ladder-defaultparams.yaml
@@ -58,7 +58,7 @@ spec:
             - --namespace=default
             - --configmap=nginx-autoscaler
             - --target=deployment/nginx-autoscale-example
-            - --default-params={"ladder":{"coresToReplicas":[[1, 1],[2, 2],[3, 4],[512, 5]],"nodesToReplicas":[[ 1,1 ],[ 2,2 ]]}}
+            - --default-params={"ladder":{"coresToReplicas":[[1, 1],[2, 2],[3, 4],[512, 5]],"nodesToReplicas":[[ 1,1 ],[ 2,2 ]],"includeUnschedulableNodes":"true"}}
             - --logtostderr=true
             - --v=2
       # Uncomment below line if you are using RBAC configs under the RBAC folder.

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -270,7 +270,7 @@ func (k *k8sClient) updateReplicasAppsV1(expReplicas int32) (prevReplicas int32,
 
 	prevReplicas = scale.Spec.Replicas
 	if expReplicas != prevReplicas {
-		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], SchedulableCores[%v]", k.clusterStatus.SchedulableNodes, k.clusterStatus.SchedulableCores)
+		glog.V(0).Infof("Cluster status: SchedulableNodes[%v], TotalNodes[%v], SchedulableCores[%v], TotalCores[%v]", k.clusterStatus.SchedulableNodes, k.clusterStatus.TotalNodes, k.clusterStatus.SchedulableCores, k.clusterStatus.TotalCores)
 		glog.V(0).Infof("Replicas are not as expected : updating replicas from %d to %d", prevReplicas, expReplicas)
 		scale.Spec.Replicas = expReplicas
 		req, err = requestForTarget(k.clientset.AppsV1().RESTClient().Put(), k.target)


### PR DESCRIPTION
# What 
This PR adds `includeUnschedulableNodes` option to ladder controller. Default value of `includeUnschedulableNodes` is false for backward compatibility. When set to `true`, ladder controller makes use of `TotalNodes` / `TotalCores` in comparison to `SchedulableNodes`/ `ScheduableCores`

# Why
As of now this option only exists for linear controller. In GKE konnectivity-agent-autoscaler makes use of ladder controller . This causes lot of issues for us on GKE clusters at the time of kubernetes version upgrade. At upgrade time,  konnectivity-agent replicas are scaled down to 1, because most of the nodes are cordoned. 