### PR TITLE
helm: set probes to use named port

### DIFF
--- a/charts/cluster-proportional-autoscaler/templates/deployment.yaml
+++ b/charts/cluster-proportional-autoscaler/templates/deployment.yaml
@@ -63,14 +63,18 @@ spec:
             {{- with .Values.options.vmodule }}
             - --vmodule={{ . }}
           {{- end }}
+          ports:
+            - containerPort: 8080
+              name: status
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: status
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: status
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The best practices docs I'm reading say to use named ports for probes and services to ensure consistency and simplify abstraction.