### PR TITLE
helm-release: Publish the helm chart as OCI artifact

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -10,18 +10,57 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
+
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: v3.0.2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR and sign
+        # when filling gaps with previously released charts, cr would create
+        # nothing in .cr-release-packages/, and the original globbing character
+        # would be preserved, causing a non-zero exit. Set nullglob to fix this
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts |& tee .digest
+            file="${pkg##*/}"       # extracts file name from full directory path
+            name="${file%-*}"       # extracts chart name from filename
+            digest="$(awk -F "[, ]+" '/Digest/{print $NF}' < .digest)"
+            cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}"@"${digest}"
+          done
+        env:
+          COSIGN_YES: true


### PR DESCRIPTION
This PR will ensure whenever a new release of the chart is published it will also be published as OCI.

the chart will be published at `ghcr.io/kubernetes-sigs/charts/cluster-proportional-autoscaler`

Same is used for couple of years here https://github.com/spiffe/helm-charts-hardened/blob/spire-0.26.1/.github/workflows/helm-release.yaml#L53-L70

Also see https://github.com/kubernetes-sigs/metrics-server/pull/1734

> [!Note]
> As the original helm release isn't touched that part of the release will not be affected. Only if the http release succeeds the workflow will try to also publish this OCI release.
>
> The risk therefore is very low.