### PR TITLE
Emit events when autoscaler changes replica count

### DIFF
--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -30,8 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/golang/glog"
 )
@@ -58,6 +61,7 @@ type k8sClient struct {
 	clientset     kubernetes.Interface
 	clusterStatus *ClusterStatus
 	nodeLister    corelisters.NodeLister
+	recorder      record.EventRecorder
 	stopCh        chan struct{}
 }
 
@@ -106,10 +110,17 @@ func NewK8sClient(clientset kubernetes.Interface, namespace, target string, node
 		return nil, err
 	}
 
+	// Create an event broadcaster and recorder to emit Kubernetes events.
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.V(0).Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events(namespace)})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cluster-proportional-autoscaler"})
+
 	return &k8sClient{
 		scaleTargets: scaleTargets,
 		clientset:    clientset,
 		nodeLister:   nodeLister,
+		recorder:     recorder,
 		stopCh:       stopCh,
 	}, nil
 }
@@ -231,12 +242,48 @@ func (k *k8sClient) GetClusterStatus() (clusterStatus *ClusterStatus, err error)
 
 func (k *k8sClient) UpdateReplicas(expReplicas int32) (err error) {
 	for _, target := range k.scaleTargets.targets {
-		_, err := k.UpdateTargetReplicas(expReplicas, target)
+		prevReplicas, err := k.UpdateTargetReplicas(expReplicas, target)
 		if err != nil {
 			return err
 		}
+		if expReplicas != prevReplicas {
+			ref := targetObjectReference(target, k.scaleTargets.namespace)
+			k.recorder.Eventf(ref, v1.EventTypeNormal, "AutoScaling",
+				"Cluster proportional autoscaler updated replicas from %d to %d (SchedulableNodes: %d, SchedulableCores: %d)",
+				prevReplicas, expReplicas,
+				k.clusterStatus.SchedulableNodes, k.clusterStatus.SchedulableCores)
+		}
 	}
 	return nil
+}
+
+// targetObjectReference builds an ObjectReference for the given scale target
+// so that events can be recorded against it.
+func targetObjectReference(t target, namespace string) *v1.ObjectReference {
+	var apiVersion, kind string
+	switch strings.ToLower(t.kind) {
+	case "deployment", "deployments":
+		apiVersion = "apps/v1"
+		kind = "Deployment"
+	case "replicaset", "replicasets":
+		apiVersion = "apps/v1"
+		kind = "ReplicaSet"
+	case "statefulset", "statefulsets":
+		apiVersion = "apps/v1"
+		kind = "StatefulSet"
+	case "replicationcontroller", "replicationcontrollers":
+		apiVersion = "v1"
+		kind = "ReplicationController"
+	default:
+		apiVersion = ""
+		kind = t.kind
+	}
+	return &v1.ObjectReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       t.name,
+		Namespace:  namespace,
+	}
 }
 
 func (k *k8sClient) UpdateTargetReplicas(expReplicas int32, target target) (prevReplicas int32, err error) {

--- a/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
+++ b/vendor/k8s.io/client-go/tools/internal/events/interfaces.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package internal is needed to break an import cycle: record.EventRecorderAdapter
+// needs this interface definition to implement it, but event.NewEventBroadcasterAdapter
+// needs record.NewBroadcaster. Therefore this interface cannot be in event/interfaces.go.
+package internal
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Eventf constructs an event from the given information and puts it in the queue for sending.
+	// 'regarding' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'related' is the secondary object for more complex actions. E.g. when regarding object triggers
+	// a creation or deletion of related object.
+	// 'type' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'action' explains what happened with regarding/what action did the ReportingController
+	// (ReportingController is a type of a Controller reporting an Event, e.g. k8s.io/node-controller, k8s.io/kubelet.)
+	// take in regarding's name; it should be in UpperCamelCase format (starting with a capital letter).
+	// 'note' is intended to be human readable.
+	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}

--- a/vendor/k8s.io/client-go/tools/record/OWNERS
+++ b/vendor/k8s.io/client-go/tools/record/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-instrumentation-reviewers
+approvers:
+  - sig-instrumentation-approvers

--- a/vendor/k8s.io/client-go/tools/record/doc.go
+++ b/vendor/k8s.io/client-go/tools/record/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package record has all client logic for recording and reporting
+// "k8s.io/api/core/v1".Event events.
+package record // import "k8s.io/client-go/tools/record"

--- a/vendor/k8s.io/client-go/tools/record/event.go
+++ b/vendor/k8s.io/client-go/tools/record/event.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+	internalevents "k8s.io/client-go/tools/internal/events"
+	"k8s.io/client-go/tools/record/util"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const maxTriesPerEvent = 12
+
+var defaultSleepDuration = 10 * time.Second
+
+const maxQueuedEvents = 1000
+
+// EventSink knows how to store events (client.Client implements it.)
+// EventSink must respect the namespace that will be embedded in 'event'.
+// It is assumed that EventSink will return the same sorts of errors as
+// pkg/client's REST client.
+type EventSink interface {
+	Create(event *v1.Event) (*v1.Event, error)
+	Update(event *v1.Event) (*v1.Event, error)
+	Patch(oldEvent *v1.Event, data []byte) (*v1.Event, error)
+}
+
+// CorrelatorOptions allows you to change the default of the EventSourceObjectSpamFilter
+// and EventAggregator in EventCorrelator
+type CorrelatorOptions struct {
+	// The lru cache size used for both EventSourceObjectSpamFilter and the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the LRUCacheSize has to be greater than 0.
+	LRUCacheSize int
+	// The burst size used by the token bucket rate filtering in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the BurstSize has to be greater than 0.
+	BurstSize int
+	// The fill rate of the token bucket in queries per second in EventSourceObjectSpamFilter
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the QPS has to be greater than 0.
+	QPS float32
+	// The func used by the EventAggregator to group event keys for aggregation
+	// If not specified (zero value), EventAggregatorByReasonFunc will be used
+	KeyFunc EventAggregatorKeyFunc
+	// The func used by the EventAggregator to produced aggregated message
+	// If not specified (zero value), EventAggregatorByReasonMessageFunc will be used
+	MessageFunc EventAggregatorMessageFunc
+	// The number of events in an interval before aggregation happens by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxEvents has to be greater than 0
+	MaxEvents int
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it is considered new by the EventAggregator
+	// If not specified (zero value), the default specified in events_cache.go will be picked
+	// This means that the MaxIntervalInSeconds has to be greater than 0
+	MaxIntervalInSeconds int
+	// The clock used by the EventAggregator to allow for testing
+	// If not specified (zero value), clock.RealClock{} will be used
+	Clock clock.PassiveClock
+	// The func used by EventFilterFunc, which returns a key for given event, based on which filtering will take place
+	// If not specified (zero value), getSpamKey will be used
+	SpamKeyFunc EventSpamKeyFunc
+}
+
+// EventRecorder knows how to record events on behalf of an EventSource.
+type EventRecorder interface {
+	// Event constructs an event from the given information and puts it in the queue for sending.
+	// 'object' is the object this event is about. Event will make a reference-- or you may also
+	// pass a reference to the object directly.
+	// 'eventtype' of this event, and can be one of Normal, Warning. New types could be added in future
+	// 'reason' is the reason this event is generated. 'reason' should be short and unique; it
+	// should be in UpperCamelCase format (starting with a capital letter). "reason" will be used
+	// to automate handling of events, so imagine people writing switch statements to handle them.
+	// You want to make that easy.
+	// 'message' is intended to be human readable.
+	//
+	// The resulting event will be created in the same namespace as the reference object.
+	Event(object runtime.Object, eventtype, reason, message string)
+
+	// Eventf is just like Event, but with Sprintf for the message field.
+	Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{})
+
+	// AnnotatedEventf is just like eventf, but with annotations attached
+	AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{})
+}
+
+// EventRecorderLogger extends EventRecorder such that a logger can
+// be set for methods in EventRecorder. Normally, those methods
+// uses the global default logger to record errors and debug messages.
+// If that is not desired, use WithLogger to provide a logger instance.
+type EventRecorderLogger interface {
+	EventRecorder
+
+	// WithLogger replaces the context used for logging. This is a cheap call
+	// and meant to be used for contextual logging:
+	//    recorder := ...
+	//    logger := klog.FromContext(ctx)
+	//    recorder.WithLogger(logger).Eventf(...)
+	WithLogger(logger klog.Logger) EventRecorderLogger
+}
+
+// EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
+type EventBroadcaster interface {
+	// StartEventWatcher starts sending events received from this EventBroadcaster to the given
+	// event handler function. The return value can be ignored or used to stop recording, if
+	// desired.
+	StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface
+
+	// StartRecordingToSink starts sending events received from this EventBroadcaster to the given
+	// sink. The return value can be ignored or used to stop recording, if desired.
+	StartRecordingToSink(sink EventSink) watch.Interface
+
+	// StartLogging starts sending events received from this EventBroadcaster to the given logging
+	// function. The return value can be ignored or used to stop recording, if desired.
+	StartLogging(logf func(format string, args ...interface{})) watch.Interface
+
+	// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured
+	// logging function. The return value can be ignored or used to stop recording, if desired.
+	StartStructuredLogging(verbosity klog.Level) watch.Interface
+
+	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
+	// with the event source set to the given event source.
+	NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger
+
+	// Shutdown shuts down the broadcaster. Once the broadcaster is shut
+	// down, it will only try to record an event in a sink once before
+	// giving up on it with an error message.
+	Shutdown()
+}
+
+// EventRecorderAdapter is a wrapper around a "k8s.io/client-go/tools/record".EventRecorder
+// implementing the new "k8s.io/client-go/tools/events".EventRecorder interface.
+type EventRecorderAdapter struct {
+	recorder EventRecorderLogger
+}
+
+var _ internalevents.EventRecorder = &EventRecorderAdapter{}
+
+// NewEventRecorderAdapter returns an adapter implementing the new
+// "k8s.io/client-go/tools/events".EventRecorder interface.
+func NewEventRecorderAdapter(recorder EventRecorderLogger) *EventRecorderAdapter {
+	return &EventRecorderAdapter{
+		recorder: recorder,
+	}
+}
+
+// Eventf is a wrapper around v1 Eventf
+func (a *EventRecorderAdapter) Eventf(regarding, _ runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	a.recorder.Eventf(regarding, eventtype, reason, note, args...)
+}
+
+func (a *EventRecorderAdapter) WithLogger(logger klog.Logger) internalevents.EventRecorderLogger {
+	return &EventRecorderAdapter{
+		recorder: a.recorder.WithLogger(logger),
+	}
+}
+
+// Creates a new event broadcaster.
+func NewBroadcaster(opts ...BroadcasterOption) EventBroadcaster {
+	c := config{
+		sleepDuration: defaultSleepDuration,
+	}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	eventBroadcaster := &eventBroadcasterImpl{
+		Broadcaster:   watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		sleepDuration: c.sleepDuration,
+		options:       c.CorrelatorOptions,
+	}
+	ctx := c.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// The are two scenarios where it makes no sense to wait for context cancelation:
+	// - The context was nil.
+	// - The context was context.Background() to begin with.
+	//
+	// Both cases get checked here: we have cancelation if (and only if) there is a channel.
+	haveCtxCancelation := ctx.Done() != nil
+
+	eventBroadcaster.cancelationCtx, eventBroadcaster.cancel = context.WithCancel(ctx)
+
+	if haveCtxCancelation {
+		// Calling Shutdown is not required when a context was provided:
+		// when the context is canceled, this goroutine will shut down
+		// the broadcaster.
+		//
+		// If Shutdown is called first, then this goroutine will
+		// also stop.
+		go func() {
+			<-eventBroadcaster.cancelationCtx.Done()
+			eventBroadcaster.Broadcaster.Shutdown()
+		}()
+	}
+
+	return eventBroadcaster
+}
+
+func NewBroadcasterForTests(sleepDuration time.Duration) EventBroadcaster {
+	return NewBroadcaster(WithSleepDuration(sleepDuration))
+}
+
+func NewBroadcasterWithCorrelatorOptions(options CorrelatorOptions) EventBroadcaster {
+	return NewBroadcaster(WithCorrelatorOptions(options))
+}
+
+func WithCorrelatorOptions(options CorrelatorOptions) BroadcasterOption {
+	return func(c *config) {
+		c.CorrelatorOptions = options
+	}
+}
+
+// WithContext sets a context for the broadcaster. Canceling the context will
+// shut down the broadcaster, Shutdown doesn't need to be called. The context
+// can also be used to provide a logger.
+func WithContext(ctx context.Context) BroadcasterOption {
+	return func(c *config) {
+		c.Context = ctx
+	}
+}
+
+func WithSleepDuration(sleepDuration time.Duration) BroadcasterOption {
+	return func(c *config) {
+		c.sleepDuration = sleepDuration
+	}
+}
+
+type BroadcasterOption func(*config)
+
+type config struct {
+	CorrelatorOptions
+	context.Context
+	sleepDuration time.Duration
+}
+
+type eventBroadcasterImpl struct {
+	*watch.Broadcaster
+	sleepDuration  time.Duration
+	options        CorrelatorOptions
+	cancelationCtx context.Context
+	cancel         func()
+}
+
+// StartRecordingToSink starts sending events received from the specified eventBroadcaster to the given sink.
+// The return value can be ignored or used to stop recording, if desired.
+// TODO: make me an object with parameterizable queue length and retry interval
+func (e *eventBroadcasterImpl) StartRecordingToSink(sink EventSink) watch.Interface {
+	eventCorrelator := NewEventCorrelatorWithOptions(e.options)
+	return e.StartEventWatcher(
+		func(event *v1.Event) {
+			e.recordToSink(sink, event, eventCorrelator)
+		})
+}
+
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
+	e.cancel()
+}
+
+func (e *eventBroadcasterImpl) recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrelator) {
+	// Make a copy before modification, because there could be multiple listeners.
+	// Events are safe to copy like this.
+	eventCopy := *event
+	event = &eventCopy
+	result, err := eventCorrelator.EventCorrelate(event)
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	if result.Skip {
+		return
+	}
+	tries := 0
+	for {
+		if recordEvent(e.cancelationCtx, sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
+			break
+		}
+		tries++
+		if tries >= maxTriesPerEvent {
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (retry limit exceeded!)", "event", event)
+			break
+		}
+
+		// Randomize the first sleep so that various clients won't all be
+		// synced up if the master goes down.
+		delay := e.sleepDuration
+		if tries == 1 {
+			delay = time.Duration(float64(delay) * rand.Float64())
+		}
+		select {
+		case <-e.cancelationCtx.Done():
+			klog.FromContext(e.cancelationCtx).Error(nil, "Unable to write event (broadcaster is shut down)", "event", event)
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// recordEvent attempts to write event to a sink. It returns true if the event
+// was successfully recorded or discarded, false if it should be retried.
+// If updateExistingEvent is false, it creates a new event, otherwise it updates
+// existing event.
+func recordEvent(ctx context.Context, sink EventSink, event *v1.Event, patch []byte, updateExistingEvent bool, eventCorrelator *EventCorrelator) bool {
+	var newEvent *v1.Event
+	var err error
+	if updateExistingEvent {
+		newEvent, err = sink.Patch(event, patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !updateExistingEvent || (updateExistingEvent && util.IsKeyNotFoundError(err)) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(event)
+	}
+	if err == nil {
+		// we need to update our event correlator with the server returned state to handle name/resourceversion
+		eventCorrelator.UpdateState(newEvent)
+		return true
+	}
+
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		klog.FromContext(ctx).Error(err, "Unable to construct event (will not retry!)", "event", event)
+		return true
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+			klog.FromContext(ctx).V(5).Info("Server rejected event (will not retry!)", "event", event, "err", err)
+		} else {
+			klog.FromContext(ctx).Error(err, "Server rejected event (will not retry!)", "event", event)
+		}
+		return true
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	klog.FromContext(ctx).Error(err, "Unable to write event (may retry after sleeping)", "event", event)
+	return false
+}
+
+// StartLogging starts sending events received from this EventBroadcaster to the given logging function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			logf("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
+		})
+}
+
+// StartStructuredLogging starts sending events received from this EventBroadcaster to a structured logger.
+// The logger is retrieved from a context if the broadcaster was constructed with a context, otherwise
+// the global default is used.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartStructuredLogging(verbosity klog.Level) watch.Interface {
+	loggerV := klog.FromContext(e.cancelationCtx).V(int(verbosity))
+	return e.StartEventWatcher(
+		func(e *v1.Event) {
+			loggerV.Info("Event occurred", "object", klog.KRef(e.InvolvedObject.Namespace, e.InvolvedObject.Name), "fieldPath", e.InvolvedObject.FieldPath, "kind", e.InvolvedObject.Kind, "apiVersion", e.InvolvedObject.APIVersion, "type", e.Type, "reason", e.Reason, "message", e.Message)
+		})
+}
+
+// StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
+// The return value can be ignored or used to stop recording, if desired.
+func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface {
+	watcher, err := e.Watch()
+	if err != nil {
+		// This function traditionally returns no error even though it can fail.
+		// Instead, it logs the error and returns an empty watch. The empty
+		// watch ensures that callers don't crash when calling Stop.
+		klog.FromContext(e.cancelationCtx).Error(err, "Unable start event watcher (will not retry!)")
+		return watch.NewEmptyWatch()
+	}
+	go func() {
+		defer utilruntime.HandleCrash()
+		for {
+			select {
+			case <-e.cancelationCtx.Done():
+				watcher.Stop()
+				return
+			case watchEvent := <-watcher.ResultChan():
+				event, ok := watchEvent.Object.(*v1.Event)
+				if !ok {
+					// This is all local, so there's no reason this should
+					// ever happen.
+					continue
+				}
+				eventHandler(event)
+			}
+		}
+	}()
+	return watcher
+}
+
+// NewRecorder returns an EventRecorder that records events with the given event source.
+func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorderLogger {
+	return &recorderImplLogger{recorderImpl: &recorderImpl{scheme, source, e.Broadcaster, clock.RealClock{}}, logger: klog.Background()}
+}
+
+type recorderImpl struct {
+	scheme *runtime.Scheme
+	source v1.EventSource
+	*watch.Broadcaster
+	clock clock.PassiveClock
+}
+
+var _ EventRecorder = &recorderImpl{}
+
+func (recorder *recorderImpl) generateEvent(logger klog.Logger, object runtime.Object, annotations map[string]string, eventtype, reason, message string) {
+	ref, err := ref.GetReference(recorder.scheme, object)
+	if err != nil {
+		logger.Error(err, "Could not construct reference, will not report event", "object", object, "eventType", eventtype, "reason", reason, "message", message)
+		return
+	}
+
+	if !util.ValidateEventType(eventtype) {
+		logger.Error(nil, "Unsupported event type", "eventType", eventtype)
+		return
+	}
+
+	event := recorder.makeEvent(ref, annotations, eventtype, reason, message)
+	event.Source = recorder.source
+
+	event.ReportingInstance = recorder.source.Host
+	event.ReportingController = recorder.source.Component
+
+	// NOTE: events should be a non-blocking operation, but we also need to not
+	// put this in a goroutine, otherwise we'll race to write to a closed channel
+	// when we go to shut down this broadcaster.  Just drop events if we get overloaded,
+	// and log an error if that happens (we've configured the broadcaster to drop
+	// outgoing events anyway).
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		logger.Error(nil, "Unable to record event: too many queued events, dropped event", "event", event)
+	}
+}
+
+func (recorder *recorderImpl) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.generateEvent(klog.Background(), object, nil, eventtype, reason, message)
+}
+
+func (recorder *recorderImpl) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(klog.Background(), object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, annotations map[string]string, eventtype, reason, message string) *v1.Event {
+	t := metav1.Time{Time: recorder.clock.Now()}
+	namespace := ref.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        message,
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventtype,
+	}
+}
+
+type recorderImplLogger struct {
+	*recorderImpl
+	logger klog.Logger
+}
+
+var _ EventRecorderLogger = &recorderImplLogger{}
+
+func (recorder recorderImplLogger) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.recorderImpl.generateEvent(recorder.logger, object, nil, eventtype, reason, message)
+}
+
+func (recorder recorderImplLogger) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	recorder.generateEvent(recorder.logger, object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (recorder recorderImplLogger) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return recorderImplLogger{recorderImpl: recorder.recorderImpl, logger: logger}
+}

--- a/vendor/k8s.io/client-go/tools/record/events_cache.go
+++ b/vendor/k8s.io/client-go/tools/record/events_cache.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+)
+
+const (
+	maxLruCacheEntries = 4096
+
+	// if we see the same event that varies only by message
+	// more than 10 times in a 10 minute period, aggregate the event
+	defaultAggregateMaxEvents         = 10
+	defaultAggregateIntervalInSeconds = 600
+
+	// by default, allow a source to send 25 events about an object
+	// but control the refill rate to 1 new event every 5 minutes
+	// this helps control the long-tail of events for things that are always
+	// unhealthy
+	defaultSpamBurst = 25
+	defaultSpamQPS   = 1. / 300.
+)
+
+// getEventKey builds unique event key based on source, involvedObject, reason, message
+func getEventKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		event.InvolvedObject.FieldPath,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.Message,
+	},
+		"")
+}
+
+// getSpamKey builds unique event key based on source, involvedObject
+func getSpamKey(event *v1.Event) string {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+	},
+		"")
+}
+
+// EventSpamKeyFunc is a function that returns unique key based on provided event
+type EventSpamKeyFunc func(event *v1.Event) string
+
+// EventFilterFunc is a function that returns true if the event should be skipped
+type EventFilterFunc func(event *v1.Event) bool
+
+// EventSourceObjectSpamFilter is responsible for throttling
+// the amount of events a source and object can produce.
+type EventSourceObjectSpamFilter struct {
+	// the cache that manages last synced state
+	cache *lru.Cache
+
+	// burst is the amount of events we allow per source + object
+	burst int
+
+	// qps is the refill rate of the token bucket in queries per second
+	qps float32
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+
+	// spamKeyFunc is a func used to create a key based on an event, which is later used to filter spam events.
+	spamKeyFunc EventSpamKeyFunc
+}
+
+// NewEventSourceObjectSpamFilter allows burst events from a source about an object with the specified qps refill.
+func NewEventSourceObjectSpamFilter(lruCacheSize, burst int, qps float32, clock clock.PassiveClock, spamKeyFunc EventSpamKeyFunc) *EventSourceObjectSpamFilter {
+	return &EventSourceObjectSpamFilter{
+		cache:       lru.New(lruCacheSize),
+		burst:       burst,
+		qps:         qps,
+		clock:       clock,
+		spamKeyFunc: spamKeyFunc,
+	}
+}
+
+// spamRecord holds data used to perform spam filtering decisions.
+type spamRecord struct {
+	// rateLimiter controls the rate of events about this object
+	rateLimiter flowcontrol.PassiveRateLimiter
+}
+
+// Filter controls that a given source+object are not exceeding the allowed rate.
+func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
+	var record spamRecord
+
+	// controls our cached information about this event
+	eventKey := f.spamKeyFunc(event)
+
+	// do we have a record of similar events in our cache?
+	value, found := f.cache.Get(eventKey)
+	if found {
+		record = value.(spamRecord)
+	}
+
+	// verify we have a rate limiter for this record
+	if record.rateLimiter == nil {
+		record.rateLimiter = flowcontrol.NewTokenBucketPassiveRateLimiterWithClock(f.qps, f.burst, f.clock)
+	}
+
+	// ensure we have available rate
+	filter := !record.rateLimiter.TryAccept()
+
+	// update the cache
+	f.cache.Add(eventKey, record)
+
+	return filter
+}
+
+// EventAggregatorKeyFunc is responsible for grouping events for aggregation
+// It returns a tuple of the following:
+// aggregateKey - key the identifies the aggregate group to bucket this event
+// localKey - key that makes this event in the local group
+type EventAggregatorKeyFunc func(event *v1.Event) (aggregateKey string, localKey string)
+
+// EventAggregatorByReasonFunc aggregates events by exact match on event.Source, event.InvolvedObject, event.Type,
+// event.Reason, event.ReportingController and event.ReportingInstance
+func EventAggregatorByReasonFunc(event *v1.Event) (string, string) {
+	return strings.Join([]string{
+		event.Source.Component,
+		event.Source.Host,
+		event.InvolvedObject.Kind,
+		event.InvolvedObject.Namespace,
+		event.InvolvedObject.Name,
+		string(event.InvolvedObject.UID),
+		event.InvolvedObject.APIVersion,
+		event.Type,
+		event.Reason,
+		event.ReportingController,
+		event.ReportingInstance,
+	},
+		""), event.Message
+}
+
+// EventAggregatorMessageFunc is responsible for producing an aggregation message
+type EventAggregatorMessageFunc func(event *v1.Event) string
+
+// EventAggregatorByReasonMessageFunc returns an aggregate message by prefixing the incoming message
+func EventAggregatorByReasonMessageFunc(event *v1.Event) string {
+	return "(combined from similar events): " + event.Message
+}
+
+// EventAggregator identifies similar events and aggregates them into a single event
+type EventAggregator struct {
+	sync.RWMutex
+
+	// The cache that manages aggregation state
+	cache *lru.Cache
+
+	// The function that groups events for aggregation
+	keyFunc EventAggregatorKeyFunc
+
+	// The function that generates a message for an aggregate event
+	messageFunc EventAggregatorMessageFunc
+
+	// The maximum number of events in the specified interval before aggregation occurs
+	maxEvents uint
+
+	// The amount of time in seconds that must transpire since the last occurrence of a similar event before it's considered new
+	maxIntervalInSeconds uint
+
+	// clock is used to allow for testing over a time interval
+	clock clock.PassiveClock
+}
+
+// NewEventAggregator returns a new instance of an EventAggregator
+func NewEventAggregator(lruCacheSize int, keyFunc EventAggregatorKeyFunc, messageFunc EventAggregatorMessageFunc,
+	maxEvents int, maxIntervalInSeconds int, clock clock.PassiveClock) *EventAggregator {
+	return &EventAggregator{
+		cache:                lru.New(lruCacheSize),
+		keyFunc:              keyFunc,
+		messageFunc:          messageFunc,
+		maxEvents:            uint(maxEvents),
+		maxIntervalInSeconds: uint(maxIntervalInSeconds),
+		clock:                clock,
+	}
+}
+
+// aggregateRecord holds data used to perform aggregation decisions
+type aggregateRecord struct {
+	// we track the number of unique local keys we have seen in the aggregate set to know when to actually aggregate
+	// if the size of this set exceeds the max, we know we need to aggregate
+	localKeys sets.String
+	// The last time at which the aggregate was recorded
+	lastTimestamp metav1.Time
+}
+
+// EventAggregate checks if a similar event has been seen according to the
+// aggregation configuration (max events, max interval, etc) and returns:
+//
+//   - The (potentially modified) event that should be created
+//   - The cache key for the event, for correlation purposes. This will be set to
+//     the full key for normal events, and to the result of
+//     EventAggregatorMessageFunc for aggregate events.
+func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, string) {
+	now := metav1.NewTime(e.clock.Now())
+	var record aggregateRecord
+	// eventKey is the full cache key for this event
+	eventKey := getEventKey(newEvent)
+	// aggregateKey is for the aggregate event, if one is needed.
+	aggregateKey, localKey := e.keyFunc(newEvent)
+
+	// Do we have a record of similar events in our cache?
+	e.Lock()
+	defer e.Unlock()
+	value, found := e.cache.Get(aggregateKey)
+	if found {
+		record = value.(aggregateRecord)
+	}
+
+	// Is the previous record too old? If so, make a fresh one. Note: if we didn't
+	// find a similar record, its lastTimestamp will be the zero value, so we
+	// create a new one in that case.
+	maxInterval := time.Duration(e.maxIntervalInSeconds) * time.Second
+	interval := now.Time.Sub(record.lastTimestamp.Time)
+	if interval > maxInterval {
+		record = aggregateRecord{localKeys: sets.NewString()}
+	}
+
+	// Write the new event into the aggregation record and put it on the cache
+	record.localKeys.Insert(localKey)
+	record.lastTimestamp = now
+	e.cache.Add(aggregateKey, record)
+
+	// If we are not yet over the threshold for unique events, don't correlate them
+	if uint(record.localKeys.Len()) < e.maxEvents {
+		return newEvent, eventKey
+	}
+
+	// do not grow our local key set any larger than max
+	record.localKeys.PopAny()
+
+	// create a new aggregate event, and return the aggregateKey as the cache key
+	// (so that it can be overwritten.)
+	eventCopy := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", newEvent.InvolvedObject.Name, now.UnixNano()),
+			Namespace: newEvent.Namespace,
+		},
+		Count:          1,
+		FirstTimestamp: now,
+		InvolvedObject: newEvent.InvolvedObject,
+		LastTimestamp:  now,
+		Message:        e.messageFunc(newEvent),
+		Type:           newEvent.Type,
+		Reason:         newEvent.Reason,
+		Source:         newEvent.Source,
+	}
+	return eventCopy, aggregateKey
+}
+
+// eventLog records data about when an event was observed
+type eventLog struct {
+	// The number of times the event has occurred since first occurrence.
+	count uint
+
+	// The time at which the event was first recorded.
+	firstTimestamp metav1.Time
+
+	// The unique name of the first occurrence of this event
+	name string
+
+	// Resource version returned from previous interaction with server
+	resourceVersion string
+}
+
+// eventLogger logs occurrences of an event
+type eventLogger struct {
+	sync.RWMutex
+	cache *lru.Cache
+	clock clock.PassiveClock
+}
+
+// newEventLogger observes events and counts their frequencies
+func newEventLogger(lruCacheEntries int, clock clock.PassiveClock) *eventLogger {
+	return &eventLogger{cache: lru.New(lruCacheEntries), clock: clock}
+}
+
+// eventObserve records an event, or updates an existing one if key is a cache hit
+func (e *eventLogger) eventObserve(newEvent *v1.Event, key string) (*v1.Event, []byte, error) {
+	var (
+		patch []byte
+		err   error
+	)
+	eventCopy := *newEvent
+	event := &eventCopy
+
+	e.Lock()
+	defer e.Unlock()
+
+	// Check if there is an existing event we should update
+	lastObservation := e.lastEventObservationFromCache(key)
+
+	// If we found a result, prepare a patch
+	if lastObservation.count > 0 {
+		// update the event based on the last observation so patch will work as desired
+		event.Name = lastObservation.name
+		event.ResourceVersion = lastObservation.resourceVersion
+		event.FirstTimestamp = lastObservation.firstTimestamp
+		event.Count = int32(lastObservation.count) + 1
+
+		eventCopy2 := *event
+		eventCopy2.Count = 0
+		eventCopy2.LastTimestamp = metav1.NewTime(time.Unix(0, 0))
+		eventCopy2.Message = ""
+
+		newData, _ := json.Marshal(event)
+		oldData, _ := json.Marshal(eventCopy2)
+		patch, err = strategicpatch.CreateTwoWayMergePatch(oldData, newData, event)
+	}
+
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+	return event, patch, err
+}
+
+// updateState updates its internal tracking information based on latest server state
+func (e *eventLogger) updateState(event *v1.Event) {
+	key := getEventKey(event)
+	e.Lock()
+	defer e.Unlock()
+	// record our new observation
+	e.cache.Add(
+		key,
+		eventLog{
+			count:           uint(event.Count),
+			firstTimestamp:  event.FirstTimestamp,
+			name:            event.Name,
+			resourceVersion: event.ResourceVersion,
+		},
+	)
+}
+
+// lastEventObservationFromCache returns the event from the cache, reads must be protected via external lock
+func (e *eventLogger) lastEventObservationFromCache(key string) eventLog {
+	value, ok := e.cache.Get(key)
+	if ok {
+		observationValue, ok := value.(eventLog)
+		if ok {
+			return observationValue
+		}
+	}
+	return eventLog{}
+}
+
+// EventCorrelator processes all incoming events and performs analysis to avoid overwhelming the system.  It can filter all
+// incoming events to see if the event should be filtered from further processing.  It can aggregate similar events that occur
+// frequently to protect the system from spamming events that are difficult for users to distinguish.  It performs de-duplication
+// to ensure events that are observed multiple times are compacted into a single event with increasing counts.
+type EventCorrelator struct {
+	// the function to filter the event
+	filterFunc EventFilterFunc
+	// the object that performs event aggregation
+	aggregator *EventAggregator
+	// the object that observes events as they come through
+	logger *eventLogger
+}
+
+// EventCorrelateResult is the result of a Correlate
+type EventCorrelateResult struct {
+	// the event after correlation
+	Event *v1.Event
+	// if provided, perform a strategic patch when updating the record on the server
+	Patch []byte
+	// if true, do no further processing of the event
+	Skip bool
+}
+
+// NewEventCorrelator returns an EventCorrelator configured with default values.
+//
+// The EventCorrelator is responsible for event filtering, aggregating, and counting
+// prior to interacting with the API server to record the event.
+//
+// The default behavior is as follows:
+//   - Aggregation is performed if a similar event is recorded 10 times
+//     in a 10 minute rolling interval.  A similar event is an event that varies only by
+//     the Event.Message field.  Rather than recording the precise event, aggregation
+//     will create a new event whose message reports that it has combined events with
+//     the same reason.
+//   - Events are incrementally counted if the exact same event is encountered multiple
+//     times.
+//   - A source may burst 25 events about an object, but has a refill rate budget
+//     per object of 1 event every 5 minutes to control long-tail of spam.
+func NewEventCorrelator(clock clock.PassiveClock) *EventCorrelator {
+	cacheSize := maxLruCacheEntries
+	spamFilter := NewEventSourceObjectSpamFilter(cacheSize, defaultSpamBurst, defaultSpamQPS, clock, getSpamKey)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			cacheSize,
+			EventAggregatorByReasonFunc,
+			EventAggregatorByReasonMessageFunc,
+			defaultAggregateMaxEvents,
+			defaultAggregateIntervalInSeconds,
+			clock),
+
+		logger: newEventLogger(cacheSize, clock),
+	}
+}
+
+func NewEventCorrelatorWithOptions(options CorrelatorOptions) *EventCorrelator {
+	optionsWithDefaults := populateDefaults(options)
+	spamFilter := NewEventSourceObjectSpamFilter(
+		optionsWithDefaults.LRUCacheSize,
+		optionsWithDefaults.BurstSize,
+		optionsWithDefaults.QPS,
+		optionsWithDefaults.Clock,
+		optionsWithDefaults.SpamKeyFunc)
+	return &EventCorrelator{
+		filterFunc: spamFilter.Filter,
+		aggregator: NewEventAggregator(
+			optionsWithDefaults.LRUCacheSize,
+			optionsWithDefaults.KeyFunc,
+			optionsWithDefaults.MessageFunc,
+			optionsWithDefaults.MaxEvents,
+			optionsWithDefaults.MaxIntervalInSeconds,
+			optionsWithDefaults.Clock),
+		logger: newEventLogger(optionsWithDefaults.LRUCacheSize, optionsWithDefaults.Clock),
+	}
+}
+
+// populateDefaults populates the zero value options with defaults
+func populateDefaults(options CorrelatorOptions) CorrelatorOptions {
+	if options.LRUCacheSize == 0 {
+		options.LRUCacheSize = maxLruCacheEntries
+	}
+	if options.BurstSize == 0 {
+		options.BurstSize = defaultSpamBurst
+	}
+	if options.QPS == 0 {
+		options.QPS = defaultSpamQPS
+	}
+	if options.KeyFunc == nil {
+		options.KeyFunc = EventAggregatorByReasonFunc
+	}
+	if options.MessageFunc == nil {
+		options.MessageFunc = EventAggregatorByReasonMessageFunc
+	}
+	if options.MaxEvents == 0 {
+		options.MaxEvents = defaultAggregateMaxEvents
+	}
+	if options.MaxIntervalInSeconds == 0 {
+		options.MaxIntervalInSeconds = defaultAggregateIntervalInSeconds
+	}
+	if options.Clock == nil {
+		options.Clock = clock.RealClock{}
+	}
+	if options.SpamKeyFunc == nil {
+		options.SpamKeyFunc = getSpamKey
+	}
+	return options
+}
+
+// EventCorrelate filters, aggregates, counts, and de-duplicates all incoming events
+func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateResult, error) {
+	if newEvent == nil {
+		return nil, fmt.Errorf("event is nil")
+	}
+	aggregateEvent, ckey := c.aggregator.EventAggregate(newEvent)
+	observedEvent, patch, err := c.logger.eventObserve(aggregateEvent, ckey)
+	if c.filterFunc(observedEvent) {
+		return &EventCorrelateResult{Skip: true}, nil
+	}
+	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err
+}
+
+// UpdateState based on the latest observed state from server
+func (c *EventCorrelator) UpdateState(event *v1.Event) {
+	c.logger.updateState(event)
+}

--- a/vendor/k8s.io/client-go/tools/record/fake.go
+++ b/vendor/k8s.io/client-go/tools/record/fake.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+// FakeRecorder is used as a fake during tests. It is thread safe. It is usable
+// when created manually and not by NewFakeRecorder, however all events may be
+// thrown away in this case.
+type FakeRecorder struct {
+	Events chan string
+
+	IncludeObject bool
+}
+
+var _ EventRecorderLogger = &FakeRecorder{}
+
+func objectString(object runtime.Object, includeObject bool) string {
+	if !includeObject {
+		return ""
+	}
+	return fmt.Sprintf(" involvedObject{kind=%s,apiVersion=%s}",
+		object.GetObjectKind().GroupVersionKind().Kind,
+		object.GetObjectKind().GroupVersionKind().GroupVersion(),
+	)
+}
+
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	if f.Events != nil {
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
+	}
+}
+
+func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
+}
+
+func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
+}
+
+func (f *FakeRecorder) WithLogger(logger klog.Logger) EventRecorderLogger {
+	return f
+}
+
+// NewFakeRecorder creates new fake event recorder with event channel with
+// buffer of given size.
+func NewFakeRecorder(bufferSize int) *FakeRecorder {
+	return &FakeRecorder{
+		Events: make(chan string, bufferSize),
+	}
+}

--- a/vendor/k8s.io/client-go/tools/record/util/util.go
+++ b/vendor/k8s.io/client-go/tools/record/util/util.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// ValidateEventType checks that eventtype is an expected type of event
+func ValidateEventType(eventtype string) bool {
+	switch eventtype {
+	case v1.EventTypeNormal, v1.EventTypeWarning:
+		return true
+	}
+	return false
+}
+
+// IsKeyNotFoundError is utility function that checks if an error is not found error
+func IsKeyNotFoundError(err error) bool {
+	statusErr, _ := err.(*errors.StatusError)
+
+	return statusErr != nil && statusErr.Status().Code == http.StatusNotFound
+}

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/golang-lru/lru.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package golang_lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	if c.OnEvicted != nil {
+		for _, e := range c.cache {
+			kv := e.Value.(*entry)
+			c.OnEvicted(kv.key, kv.value)
+		}
+	}
+	c.ll = nil
+	c.cache = nil
+}

--- a/vendor/k8s.io/utils/lru/lru.go
+++ b/vendor/k8s.io/utils/lru/lru.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	groupcache "k8s.io/utils/internal/third_party/forked/golang/golang-lru"
+)
+
+type Key = groupcache.Key
+type EvictionFunc = func(key Key, value interface{})
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	cache *groupcache.Cache
+	lock  sync.RWMutex
+}
+
+// New creates an LRU of the given size.
+func New(size int) *Cache {
+	return &Cache{
+		cache: groupcache.New(size),
+	}
+}
+
+// NewWithEvictionFunc creates an LRU of the given size with the given eviction func.
+func NewWithEvictionFunc(size int, f EvictionFunc) *Cache {
+	c := New(size)
+	c.cache.OnEvicted = f
+	return c
+}
+
+// SetEvictionFunc updates the eviction func
+func (c *Cache) SetEvictionFunc(f EvictionFunc) error {
+	if c.cache.OnEvicted != nil {
+		return fmt.Errorf("lru cache eviction function is already set")
+	}
+	c.cache.OnEvicted = f
+	return nil
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Add(key, value)
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.cache.Get(key)
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Remove(key)
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.RemoveOldest()
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.Len()
+}
+
+// Clear purges all stored items from the cache.
+func (c *Cache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Clear()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -587,8 +587,11 @@ k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/tools/clientcmd/api/latest
 k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/internal/events
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/record
+k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference
 k8s.io/client-go/transport
 k8s.io/client-go/util/apply
@@ -628,7 +631,9 @@ k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/clock/testing
+k8s.io/utils/internal/third_party/forked/golang/golang-lru
 k8s.io/utils/internal/third_party/forked/golang/net
+k8s.io/utils/lru
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/ptr


### PR DESCRIPTION
**Closes #39**

Emits Kubernetes events on the target resource (Deployment, ReplicaSet, StatefulSet, or ReplicationController) whenever the cluster-proportional-autoscaler changes the number of replicas. This surfaces autoscaling activity through the standard kubectl describe and kubectl get events workflows.

**Changes**
k8sclient.go
 (only production file changed):

Added an EventRecorder to the k8sClient struct, initialized via a record.EventBroadcaster in NewK8sClient. The broadcaster logs events through glog and records them to the Kubernetes API server.
Updated UpdateReplicas to emit a Normal/AutoScaling event after a successful replica change. The event message includes old and new replica counts plus current cluster status (schedulable nodes and cores).
Added targetObjectReference helper to map internal target kinds to proper v1.ObjectReference values so events attach to the correct resource.
No changes to the K8sClient interface or MockK8sClient — event recording is an internal implementation detail.

**Example output**
$ kubectl describe deployment my-dns
Events:
```
  Type    Reason       From                                Message
  Normal  AutoScaling  cluster-proportional-autoscaler     Cluster proportional autoscaler updated replicas from 3 to 5 (SchedulableNodes: 10, SchedulableCores: 40)
 ```
**Testing**
All existing tests pass (go test ./...).
The mock client is unaffected since the K8sClient interface is unchanged.